### PR TITLE
Fix RK45 dense-output FSAL corruption and restore local extrapolation

### DIFF
--- a/src/RK45.jl
+++ b/src/RK45.jl
@@ -178,13 +178,17 @@ function step!(s)
     s.ok && (s.ks[1] .= s.ks[end])
     evaluate!(s)
 
-    if s.locextrap
-        s.yn .= s.y
-        for jj = 1:7
-            b5[jj] == 0 || (s.yn .+= s.dt*b5[jj].*s.ks[jj])
-        end
+    # Propagate the 5th-order solution (local extrapolation, the default) or the embedded
+    # 4th-order one. Both are formed explicitly rather than reusing the stage-6
+    # accumulation evaluate! happens to leave in yn -- which is the 5th-order solution --
+    # so this does not depend on the RHS leaving its input array alone. For locextrap the
+    # two are bit-identical anyway: b5[1:6] == B[6], b5[7] == 0, same accumulation order.
+    bprop = s.locextrap ? b5 : b4
+    s.yn .= s.y
+    for jj = 1:7
+        bprop[jj] == 0 || (s.yn .+= s.dt*bprop[jj].*s.ks[jj])
     end
-    
+
     fill!(s.yerr, 0)
     for ii = 1:7
         errest[ii] == 0 || (@. s.yerr += s.dt*s.ks[ii]*errest[ii])

--- a/src/RK45.jl
+++ b/src/RK45.jl
@@ -106,7 +106,8 @@ mutable struct Stepper{T<:AbstractArray, F, nT}
     max_dt::Float64  # maximum value for dt (default Inf)
     min_dt::Float64  # minimum value for dt (default 0)
     locextrap::Bool  # true if using local extrapolation
-    ok::Bool  # true if current step was successful
+    ok::Bool  # true if current step was successful. Also means "an FSAL move is owed"
+              # (see step!), so nothing may write it after step! has returned.
     err::Float64  # error metric to be compared to tol
     errlast::Float64  # error of the most recent successful step
     norm::nT # function to calculate error metric, defaults to RK45.weaknorm
@@ -143,7 +144,8 @@ mutable struct PreconStepper{T<:AbstractArray, F, P, nT}
     max_dt::Float64  # maximum value for dt (default Inf)
     min_dt::Float64  # minimum value for dt (default 0)
     locextrap::Bool  # true if using local extrapolation
-    ok::Bool  # true if current step was successful
+    ok::Bool  # true if current step was successful. Also means "an FSAL move is owed"
+              # (see step!), so nothing may write it after step! has returned.
     err::Float64  # error metric to be compared to tol
     errlast::Float64  # error of the most recent successful step
     norm::nT  # function to calculate error metric, defaults to RK45.weaknorm
@@ -165,6 +167,15 @@ function PreconStepper(f!, linop, y0, t, dt;
 end
 
 function step!(s)
+    # FSAL: k7 of the previous step is k1 of this one. The move is deferred to here
+    # (rather than done at the end of step!) because the completed step's dense output is
+    # consumed between step! returning and this call, and the interpolant's k1 weight is
+    # nonzero (interpC column 1; b1(1) = 35/384) -- moving it any earlier degrades every
+    # interpolated save from 4th to 2nd order. s.ok is false before the first step (ks[2:7]
+    # are `similar`, i.e. undef) and after a rejected step (k1 must survive for the retry).
+    # For the PreconStepper this must also stay ahead of evaluate!'s rebase of ks[1] into
+    # the new anchor frame, which it does by construction.
+    s.ok && (s.ks[1] .= s.ks[end])
     evaluate!(s)
 
     if s.locextrap
@@ -183,7 +194,6 @@ function step!(s)
     stepcontrolPI!(s)
     if s.ok
         s.tn = s.t + s.dt
-        s.ks[1] .= s.ks[end]
     else
         s.yn .= s.y
     end

--- a/src/dopri.jl
+++ b/src/dopri.jl
@@ -10,12 +10,14 @@ const B = [[1/5],
 # Step size fractions
 const nodes = [1/5, 3/10, 4/5, 8/9, 1, 1]
 
-# Weights for 5th order method
-const b5 = [5179/57600, 0, 7571/16695, 393/640, -92097/339200, 187/2100, 1/40]
-# Weights for 4th order method
-const b4 = [35/384, 0, 500/1113, 125/192, -2187/6784, 11/84, 0]
-# Error estimate
-const errest = b5 .- b4
+# Weights for 5th order method. These are also the final Butcher row B[6]: DOPRI5 is FSAL,
+# so stage 7 is the RHS evaluated at exactly this solution, and the dense-output polynomial
+# at σ=1 reproduces it too (sum(interpC, dims=1) == b5). Propagated when locextrap=true.
+const b5 = [35/384, 0, 500/1113, 125/192, -2187/6784, 11/84, 0]
+# Weights for the embedded 4th order method. Propagated when locextrap=false.
+const b4 = [5179/57600, 0, 7571/16695, 393/640, -92097/339200, 187/2100, 1/40]
+# Error estimate: (4th order) - (5th order).
+const errest = b4 .- b5
 
 #Interpolation coefficients
 const interpC = hcat(

--- a/test/test_rk45.jl
+++ b/test/test_rk45.jl
@@ -1,4 +1,5 @@
 import FFTW
+import Logging
 import Luna: RK45
 import Test: @test
 
@@ -133,4 +134,112 @@ zarrpf, Aarrpf = RK45.solve_precon(fnl!, Linfunc, copy(Aω), z, dz, zmax,
 @test isapprox(abs2.(Aarrpf[:, 1]), abs2.(Aarrpf[:, end]), rtol=1e-3)
 # Is there a difference if the linear part is a function (but constant)?
 @test all(abs2.(Aarrp) .== abs2.(Aarrpf))
+
+# --- dense output (interpolant) accuracy ------------------------------------
+# DOPRI5 is FSAL: k7 of a step is k1 of the next. That move must not happen
+# until the completed step's dense output has been consumed, because the
+# interpolant's k1 weight is nonzero (interpC column 1, b1(1) = 35/384). Doing
+# it inside the step poisons every interpolated save by dt*b1(σ)*(k7 - k1),
+# which is O(h²) -- the dense output drops from 4th to 2nd order while the
+# stepped endpoints, and therefore almost every other test, stay untouched.
+#
+# Test problem: y' = i(a + |y|²)y on a single element. |y| is conserved, so
+#     y(t) = y(t₀)*exp(i(a + |y(t₀)|²)(t - t₀))
+# exactly -- and the same holds for the preconditioned split with
+# linop = [i*a] and nonlinear part i|y|²y. Setting min_dt == max_dt == h pins
+# every step to exactly h (steplims! clamps from both sides), so the
+# convergence studies below are fixed-step and cannot be disturbed by the
+# step-size controller.
+
+dns_a = 3.0
+dns_f!(o, y, t) = (o[1] = im*(dns_a + abs2(y[1]))*y[1]; o)
+dns_fnl!(o, y, t) = (o[1] = im*abs2(y[1])*y[1]; o)
+dns_lin = ComplexF64[im*dns_a]
+dns_y0() = ComplexF64[1.0]
+"Exact solution at `t` of the trajectory passing through `y` at `t0`."
+dns_exact(y, t0, t) = y*exp(im*(dns_a + abs2(y))*(t - t0))
+
+dns_stepper(h; precon=false, rtol=1e-2, locextrap=true) = precon ?
+    RK45.PreconStepper(dns_fnl!, dns_lin, dns_y0(), 0.0, h;
+                       rtol=rtol, min_dt=h, max_dt=h, locextrap=locextrap) :
+    RK45.Stepper(dns_f!, dns_y0(), 0.0, h;
+                 rtol=rtol, min_dt=h, max_dt=h, locextrap=locextrap)
+
+"""
+Run the model problem to `tmax` with every step pinned to exactly `h`, probing
+the dense output of each completed step. Returns
+    eloc:   max over steps of the dense-output error at the step midpoint,
+            measured against the exact solution continued from that step's own
+            starting value, so the trajectory's accumulated error cannot mask it
+    eslope: max over steps of the relative error in the interpolant's slope at
+            the start of the step, which must be f(y(tₙ)). This sees the FSAL
+            corruption directly, without any convergence study
+    eglob:  max over steps of the error of the stepped solution itself
+    egap:   max over steps of the mismatch between the interpolant just inside
+            the step endpoint and the stepped endpoint yn
+    nsteps, dterr: step count, and max deviation of the realised step from `h`
+"""
+function dns_probe(h; precon=false, tmax=2.0, rtol=1e-2, locextrap=true)
+    y0 = dns_y0()
+    tprev = 0.0
+    yprev = copy(y0)
+    eloc = 0.0; eslope = 0.0; eglob = 0.0; egap = 0.0; nsteps = 0; dterr = 0.0
+    probe = function (yn, tn, dtn, interp)
+        dtk = tn - tprev  # the 3rd argument is the *next* step size, not this one
+        dterr = max(dterr, abs(dtk - h))
+        y0k = yprev[1]
+        tm = tprev + dtk/2
+        eloc = max(eloc, abs(interp(tm)[1] - dns_exact(y0k, tprev, tm)))
+        δ = 1e-6*dtk
+        slope = (interp(tprev + δ)[1] - y0k)/δ
+        exslope = im*(dns_a + abs2(y0k))*y0k
+        eslope = max(eslope, abs(slope - exslope)/abs(exslope))
+        egap = max(egap, abs(interp(tn - 10*eps(abs(tn)))[1] - yn[1])/abs(yn[1]))
+        eglob = max(eglob, abs(yn[1] - dns_exact(y0[1], 0.0, tn)))
+        nsteps += 1
+        tprev = tn
+        yprev .= yn  # yn is the stepper's live buffer, so copy it
+    end
+    Logging.with_logger(Logging.NullLogger()) do
+        RK45.solve(dns_stepper(h; precon=precon, rtol=rtol, locextrap=locextrap),
+                   tmax; stepfun=probe)
+    end
+    (eloc=eloc, eslope=eslope, eglob=eglob, egap=egap, nsteps=nsteps, dterr=dterr)
+end
+
+# A step must leave ks[1] alone: the FSAL move belongs to the *next* step, after
+# the dense output of this one has been consumed. (For the PreconStepper the
+# first step's rebase of ks[1] is prop!(., t, t), an exact identity, so the
+# comparison is bitwise for both stepper types.)
+for dns_precon in (false, true)
+    s = dns_stepper(0.1; precon=dns_precon)
+    dns_k1 = copy(s.ks[1])
+    @test RK45.step!(s)
+    @test s.ks[1] == dns_k1  # still pending...
+    @test RK45.step!(s)
+    @test s.ks[1] != dns_k1  # ...and performed by the next step
+end
+
+for dns_precon in (false, true)
+    r1 = dns_probe(0.1; precon=dns_precon)
+    r2 = dns_probe(0.025; precon=dns_precon)
+    # the steps really were pinned to h, so the convergence study is meaningful
+    @test r1.dterr < 1e-9
+    @test r2.dterr < 1e-9
+    @test r1.nsteps >= 20
+    @test r2.nsteps >= 80
+    # The interpolant must leave the step start along f(y(tₙ)). With the FSAL
+    # move done too early this is wrong at the 40% (plain) / 2.5% (precon)
+    # level; correct, it is 2e-5 / 2e-7 at h = 0.1.
+    @test r1.eslope < 1e-3
+    @test r2.eslope < 1e-5
+    # Convergence order of the pure dense-output error: 4 or better. With the
+    # FSAL move done too early it is exactly 2.
+    @test log(r1.eloc/r2.eloc)/log(4) > 3.5
+    @test r1.eloc < 1e-4  # buggy: 1.6e-2 (plain), 1.0e-3 (precon)
+    # With min_dt == max_dt every step is accepted only because steplims!
+    # forces ok = true; the FSAL move must be made on those steps too, and the
+    # result must not depend on the tolerance that is being overridden.
+    @test dns_probe(0.1; precon=dns_precon, rtol=1e-14) == r1
+end
 

--- a/test/test_rk45.jl
+++ b/test/test_rk45.jl
@@ -243,3 +243,56 @@ for dns_precon in (false, true)
     @test dns_probe(0.1; precon=dns_precon, rtol=1e-14) == r1
 end
 
+# --- which weight vector is which ------------------------------------------
+# The two vectors of the Dormand-Prince RK5(4)7M pair, as exact rationals. They
+# are told apart by the quadrature order conditions Σᵢbᵢcᵢᵖ = 1/(p+1): the
+# 5th-order vector satisfies them through p = 4, the embedded 4th-order one only
+# through p = 3. dopri.jl had the two labelled the wrong way round, so
+# locextrap=true propagated the *lower*-order solution; these tests pin the
+# correction down.
+dns_c = Rational{BigInt}[0, 1//5, 3//10, 4//5, 8//9, 1, 1]
+dns_v5 = Rational{BigInt}[35//384, 0, 500//1113, 125//192, -2187//6784, 11//84, 0]
+dns_v4 = Rational{BigInt}[5179//57600, 0, 7571//16695, 393//640, -92097//339200,
+                          187//2100, 1//40]
+dns_quad(b, p) = sum(b .* dns_c.^p) == 1//(p + 1)
+@test all(p -> dns_quad(dns_v5, p), 0:4)
+@test all(p -> dns_quad(dns_v4, p), 0:3)
+@test !dns_quad(dns_v4, 4)
+@test RK45.b5 == Float64.(dns_v5)
+@test RK45.b4 == Float64.(dns_v4)
+# DOPRI5 is FSAL: the final Butcher row is the 5th-order solution, which is
+# therefore where stage 7 is evaluated, and which the dense output reproduces
+# at σ = 1.
+@test RK45.b5[1:6] == RK45.B[6]
+@test RK45.b5[7] == 0
+@test vec(sum(RK45.interpC, dims=1)) ≈ RK45.b5
+# The error estimate is untouched by the relabelling: it is still the standard
+# DOPRI5 E vector, (4th order) - (5th order).
+@test RK45.errest ≈ [-71/57600, 0, 71/16695, -71/1920, 17253/339200, -22/525, 1/40]
+
+# The stepped solution converges at 5th order with local extrapolation (the
+# default) and at 4th without it; and with local extrapolation the interpolant
+# is a continuous extension of the solution actually propagated, so at the step
+# endpoint it reproduces yn to round-off. Without it the two differ by the full
+# embedded error estimate -- which is why interpolate() cannot simply be trusted
+# at σ ≈ 1.
+for dns_precon in (false, true)
+    r1 = dns_probe(0.1; precon=dns_precon)
+    r2 = dns_probe(0.025; precon=dns_precon)
+    n1 = dns_probe(0.1; precon=dns_precon, locextrap=false)
+    n2 = dns_probe(0.025; precon=dns_precon, locextrap=false)
+    @test log(r1.eglob/r2.eglob)/log(4) > 4.6
+    @test 3.5 < log(n1.eglob/n2.eglob)/log(4) < 4.6
+    @test r1.egap < 1e-12
+    @test n1.egap > 1e-9
+end
+
+# FSAL is exact: k7 is the RHS evaluated at the solution that is propagated, so
+# after a step ks[1] is the RHS at that step's own endpoint.
+dns_s = dns_stepper(0.1)
+RK45.step!(dns_s)
+RK45.step!(dns_s)  # the second step performs the deferred FSAL move
+dns_fk = similar(dns_s.y)
+dns_f!(dns_fk, dns_s.y, dns_s.t)
+@test dns_s.ks[1] ≈ dns_fk rtol=1e-13
+


### PR DESCRIPTION
Two independent defects in the DOPRI5 integrator, as two separate commits because their blast radii are very different: the first leaves the stepped trajectory bit-identical, the second changes the result of every simulation.

## 1. `7747c93` — the FSAL move ran before the dense output was consumed

`step!` performed the FSAL move (`k7` of the completed step becomes `k1` of the next) inside its accept branch, but `solve` consumes that step's dense output *after* `step!` returns — both the `output=true` saves and the interpolant closure handed to `stepfun`. Every interpolated save therefore evaluated the dense-output polynomial with `k7` sitting in the `k1` slot, and the `k1` weight is not zero (`interpC` column 1, `b1(1) = 35/384`), so each value carried a spurious `dt*b1(σ)*(k7 − k1) = O(h²)` term. **The dense output was 2nd order instead of 4th.**

Not a corner case: `Luna.run` leaves `step_on` unset by default and `Output.GridCondition` saves via `yfun(ts)` with `ts < tn`, so every saved z-slice of a default run is an interpolated value. Runs that pass `step_on` aligned to the save grid were unaffected — those saves are exact step endpoints.

The fix moves it to the top of `step!`, guarded by the previous step's `s.ok`. `step!` is `evaluate!`'s only caller, so this is one site with one guard, and it stays ahead of `evaluate!(::PreconStepper)`'s rebase of `ks[1]` into the new anchor frame — the copy must still happen in the old frame, exactly as before.

## 2. `1d7e4c3` — `locextrap=true` propagated the *lower*-order solution

`dopri.jl` had the two weight vectors of the Dormand–Prince RK5(4)7M pair labelled the wrong way round. `b5`, commented "Weights for 5th order method", held `[5179/57600, …]`, which is the embedded **4th**-order vector; `b4` held `[35/384, …]`, the 5th-order one. `step!` propagated `b5`, so `locextrap=true` — the default, and the only setting anything in the repo ever uses — ran the lower-order solution of the pair.

Told apart by the quadrature order conditions `Σᵢ bᵢcᵢᵖ = 1/(p+1)` in exact rational arithmetic: `[35/384, …]` satisfies them through `p = 4`; `[5179/57600, …]` gives `Σbc⁴ = 0.19974 ≠ 1/5`, so it cannot be 5th order. `[35/384, …]` is also the final Butcher row `B[6]` and the σ=1 value of the dense-output polynomial — both consequences of DOPRI5 being FSAL, neither true of the other vector — and it is what scipy's `RK45` and MATLAB's `ode45` propagate.

The commit swaps the values so the names mean what they say and selects between them in `step!`. `errest` is unchanged (`b5 - b4` became `b4 - b5`: the same numbers, still `(4th) − (5th)`), so the error estimate and the PI controller's `1/5` exponent are untouched. Both branches now form `yn` explicitly rather than one of them relying on the stage-6 accumulation `evaluate!` happens to leave behind, so the result no longer depends on the RHS leaving its input array alone.

Two things fall out. FSAL becomes exact — stage 7 is the RHS evaluated at the solution that is now actually propagated. And the dense output becomes a continuous extension of the propagated solution: at the endpoint the interpolant reproduces `yn` to round-off instead of differing by the full embedded error estimate.

## Measurements

Fixed-step model problem with an exact solution (`y' = i(a + |y|²)y`, `h = 0.1` and `0.025`):

| | master | after 7747c93 | after 1d7e4c3 |
|---|---|---|---|
| dense-output order (plain / precon) | 2.00 / 2.00 | 4.90 / 4.99 | 4.90 / 4.99 |
| interpolant slope error at step start | 4.0e-1 / 2.5e-2 | 2.2e-5 / 2.0e-7 | 2.0e-7 / 2.0e-7 |
| endpoint order | 4.22 / 4.01 | 4.22 / 4.01 | **5.00 / 5.29** |
| FSAL residual \|ks[1] − f(t,y)\| | 4.0e-1 | 2.3e-5 | **0** |
| interpolant vs `yn` at the endpoint | 1.4e-2 | 2.1e-5 | **1.9e-14** |

N=5 soliton problem at `rtol=1e-8` (exact conserved energy 1638400):

- `7747c93`: stepped trajectory **bit-identical** — step count and hashes of the `z`, `dz` and final-field sequences all unchanged, both steppers. The summed energy of 51 interpolated saves moves from `8.35581116e7` to `8.35584000e7`, against an exact `8.3558400113e7`.
- `1d7e4c3`: endpoint energy error `2.2e-3 → 1.1e-4` in `21944 → 14328` steps (plain) and `4.6e-1 → 7.6e-3` in 5426 steps (precon). 20–60× more accurate at the same tolerance, and 35% fewer steps for the plain stepper — the old FSAL inconsistency was inflating the error estimate too.

## Tests

162 new lines in `test/test_rk45.jl`, on a 1-element problem that is exact for both steppers and for the preconditioned split (`|y|` is conserved), with `min_dt == max_dt == h` pinning every step:

- white-box: `ks[1]` must survive a `step!` and change on the next one;
- the interpolant's slope at the step start must be `f(y(tₙ))`, not `f` at the far end;
- convergence order of the pure dense-output error, measured against the exact solution continued from each step's own start so the trajectory's accumulated error can't mask it;
- the order conditions above, in exact rational arithmetic, pinning which vector is which permanently;
- endpoint convergence order, FSAL exactness, and interpolant/endpoint continuity;
- guards that the steps really were pinned to `h`, plus a repeat at `rtol=1e-14` where every step is accepted only by the `min_dt` clamp, exercising the `steplims!`-forces-`ok=true` path the deferred move must preserve.

## Reviewer notes

- Full suite: **4351 pass, 12 broken (pre-existing), 0 failures**, all 31 test files. No literal needed re-baselining, including `test_gnlse.jl`'s `argmax` comparisons at `rtol=1e-14`.
- Verified for the preconditioned path specifically (the one `Luna.run` uses): all `kᵢ` live in the frame anchored at the step start; the deferred copy stays ahead of `prop!(ks[1], t, tn)` so it is still rebased in the old frame; `prop!_maybe` and `interpolate`'s trailing `prop!(out, t, ti)` still transform saved output to the lab frame on every path.
- The window/filter surgery in `Luna.run`'s `stepfun` (`Eω .*= ωwin`, `twin`) mutates `s.yn` in place after each step, so the FSAL `k1` is evaluated at the un-windowed endpoint. Pre-existing and unchanged by either commit — commit 2 slightly reduces the residual inconsistency.
- `#2` supersedes the rationale for `step_on` only partly: the dense output is still 4th order while the endpoints are now 5th, so landing weak-signal saves on step endpoints is still worthwhile.
- Both are branched off `master`, deliberately separate from the in-flight perf work. Cherry-picking onto that branch will need three assertions in its `test_rk45.jl` inverted (`sum(interpC) ≈ b4` → `b5`), its endpoint-snap comment rewritten (the σ=1 mismatch it describes no longer exists), and its in-place-`fbar!` fix-up dropped as redundant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
